### PR TITLE
Updated path for zizmor

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -25,6 +25,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
-
       - name: Run zizmor 🌈
         uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8
+        with:
+          inputs: .github/


### PR DESCRIPTION
Updated path for zizmor

## Summary by Sourcery

CI:
- Update the zizmor workflow to pass the .github/ directory as the action input.